### PR TITLE
Accept headers

### DIFF
--- a/src/SMTPMailer.php
+++ b/src/SMTPMailer.php
@@ -38,7 +38,7 @@ class SMTPMailer implements MailerInterface
      * @param $password
      * @param array $options
      */
-    public function __construct($smtpHost, $username, $password, array $options = [])
+    public function __construct($smtpHost, $username, $password, array $options = [], $headers = [])
     {
         $this->smtpHost = $smtpHost;
         $this->username = $username;
@@ -53,6 +53,9 @@ class SMTPMailer implements MailerInterface
         $mailer->Password   = $this->password;                               // SMTP password
         $mailer->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;         // Enable TLS encryption; `PHPMailer::ENCRYPTION_SMTPS` also accepted
         $mailer->Port       = !isset($options['port']) ? 587 : intval($options['port']);
+        foreach ($headers as $header => $value) {
+          $mailer->AddCustomHeader( "$header: $value" );
+        }
         $this->processor = $mailer;
     }
 


### PR DESCRIPTION
We need to add the List-unsubscribe header when using this - 

https://help.returnpath.com/hc/en-us/articles/222445307-What-is-the-List-Unsubscribe-header-#:~:text=The%20List%2DUnsubscribe%20header%20is,Outlook.com%2C%20and%20others.

This change would allow headers to be passed in

Not in this PR - but We are also wanting to set 
```
	$mail->SMTPOptions = array( # internal cert doesn't match internal hostname
		'ssl' => array(
			'verify_peer_name' => false,
		)
	);

```

I note AmazonSes accepts some extra construct params for that

```
        $this->verifyPeer = $verifyPeer;
        $this->verifyHost = $verifyHost;
```